### PR TITLE
Fix response for notification events

### DIFF
--- a/src/Notifications/SmsirChannel.php
+++ b/src/Notifications/SmsirChannel.php
@@ -29,7 +29,9 @@ class SmsirChannel
 
         $message = $notification->toSmsir($notifiable);
 
-        $this->client->send()->verify($to, $message->template_id, $message->parameters);
+        $response = $this->client->send()->verify($to, $message->template_id, $message->parameters);
+
+        return $response;
     }
 
 


### PR DESCRIPTION
https://laravel.com/docs/11.x/notifications#notification-sent-event

توی لاراول زمان ارسال پیام توسط Notification مبتونیم از NotificationSent برای گوش دادن به شنونده های استفاده کنیم تا response های پیامی که ارسال کردیم رو بررسی کنیم و ... (لینک بالا رو بررسی کنید)

اما شما resonse بر نمیگردونید پس من این کار رو کردم :)

https://github.com/laravel/framework/blob/11.x/src/Illuminate/Notifications/NotificationSender.php#L148

لینک بالا نشون میده که لاراول چطوری response رو دریافت میکنه تا اونو به شنونده بفرسته
```
        $response = $this->manager->driver($channel)->send($notifiable, $notification);
```

اینجا ما انتظار داریم که response بر گردونده شه که در حال حاضر null بر میگردونید