### PR TITLE
Check if the toSmsir method returns a response

### DIFF
--- a/src/Contracts/Response.php
+++ b/src/Contracts/Response.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Cryptommer\Smsir\Contracts;
+
+interface Response
+{
+    public function getData();
+
+    public function getMessage();
+
+    public function getStatus();
+}

--- a/src/Notifications/SmsirChannel.php
+++ b/src/Notifications/SmsirChannel.php
@@ -3,6 +3,7 @@
 namespace Cryptommer\Smsir\Notifications;
 
 use Cryptommer\Smsir\Classes\Smsir;
+use Cryptommer\Smsir\Contracts\Response;
 use Illuminate\Notifications\Notification;
 
 class SmsirChannel
@@ -28,6 +29,10 @@ class SmsirChannel
         }
 
         $message = $notification->toSmsir($notifiable);
+
+        if($message instanceof Response) {
+            return $message;
+        };
 
         $response = $this->client->send()->verify($to, $message->template_id, $message->parameters);
 

--- a/src/Objects/BulkResponse.php
+++ b/src/Objects/BulkResponse.php
@@ -2,12 +2,13 @@
 
 namespace Cryptommer\Smsir\Objects;
 
+use Cryptommer\Smsir\Contracts\Response;
 use Illuminate\Support\Carbon;
 use PhpParser\Node\Expr\Array_;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 
-class BulkResponse {
+class BulkResponse implements Response {
 
     /**
      * @var String

--- a/src/Objects/CreditResponse.php
+++ b/src/Objects/CreditResponse.php
@@ -2,9 +2,10 @@
 
 namespace Cryptommer\Smsir\Objects;
 
+use Cryptommer\Smsir\Contracts\Response;
 use Psr\Http\Message\StreamInterface;
 
-class CreditResponse {
+class CreditResponse implements Response {
     /**
      * @var int
      */

--- a/src/Objects/LikeToLikeResponse.php
+++ b/src/Objects/LikeToLikeResponse.php
@@ -2,12 +2,13 @@
 
 namespace Cryptommer\Smsir\Objects;
 
+use Cryptommer\Smsir\Contracts\Response;
 use Illuminate\Support\Carbon;
 use PhpParser\Node\Expr\Array_;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 
-class LikeToLikeResponse {
+class LikeToLikeResponse implements Response {
 
 
     /**

--- a/src/Objects/LineResponse.php
+++ b/src/Objects/LineResponse.php
@@ -2,9 +2,10 @@
 
 namespace Cryptommer\Smsir\Objects;
 
+use Cryptommer\Smsir\Contracts\Response;
 use Psr\Http\Message\StreamInterface;
 
-class LineResponse {
+class LineResponse implements Response {
     /**
      * @var int
      */

--- a/src/Objects/ReceiveResponse.php
+++ b/src/Objects/ReceiveResponse.php
@@ -2,9 +2,10 @@
 
 namespace Cryptommer\Smsir\Objects;
 
+use Cryptommer\Smsir\Contracts\Response;
 use Psr\Http\Message\StreamInterface;
 
-class ReceiveResponse {
+class ReceiveResponse implements Response {
 
 
     /**

--- a/src/Objects/ReportResponse.php
+++ b/src/Objects/ReportResponse.php
@@ -2,9 +2,10 @@
 
 namespace Cryptommer\Smsir\Objects;
 
+use Cryptommer\Smsir\Contracts\Response;
 use Psr\Http\Message\StreamInterface;
 
-class ReportResponse {
+class ReportResponse implements Response {
 
     /**
      * @var String

--- a/src/Objects/Response.php
+++ b/src/Objects/Response.php
@@ -2,9 +2,10 @@
 
 namespace Cryptommer\Smsir\Objects;
 
+use Cryptommer\Smsir\Contracts\Response as ContractsResponse;
 use Psr\Http\Message\StreamInterface;
 
-class Response {
+class Response implements ContractsResponse {
 
     /**
      * @var String

--- a/src/Objects/ScheduleResponse.php
+++ b/src/Objects/ScheduleResponse.php
@@ -2,12 +2,13 @@
 
 namespace Cryptommer\Smsir\Objects;
 
+use Cryptommer\Smsir\Contracts\Response;
 use Illuminate\Support\Carbon;
 use PhpParser\Node\Expr\Array_;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 
-class ScheduleResponse {
+class ScheduleResponse implements Response {
 
     /**
      * @var String

--- a/src/Objects/VerifyResponse.php
+++ b/src/Objects/VerifyResponse.php
@@ -2,12 +2,13 @@
 
 namespace Cryptommer\Smsir\Objects;
 
+use Cryptommer\Smsir\Contracts\Response;
 use Illuminate\Support\Carbon;
 use PhpParser\Node\Expr\Array_;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 
-class VerifyResponse {
+class VerifyResponse implements Response {
 
 
     /**


### PR DESCRIPTION
شرح مشکل:
با سلام,  در فایل src/Notifications/SmsirChannel.php همچین چیزی داریم:
```php
  $message = $notification->toSmsir($notifiable);

  $response = $this->client->send()->verify($to, $message->template_id, $message->parameters);
```

که ما اول `$message` رو دریافت میکنیم و بعد به `()verify` درخواست میدیم و `$message->template_id` و `$message->parameters` رو به عنوان پارامتر بهش پاس میدیم.

مشکل اینجاست که ما محدود به متد verify هست, اگر برنامه نویس بخواد از بقیه متد ها استفاده کنه مجبور هست به صورت pure ازشون استفاده کنه و نمیتونه ازشون در notification ها استفاده کنه.

این کامیت اجازه میده که انعطاف پذیری استفاده از متد های مختلف در $notification ها میسر بشه

مثال پایین رو نگا کنین:
```php
    public function via(object $notifiable): array
    {
        return [SmsirChannel::class];
    }

    /**
     * Get the mail representation of the notification.
     */
    public function toSmsir(object $notifiable): BulkResponse
    {
        return Smsir::send()->Bulk(__('notification.register'), [$notifiable->phone]);
    }
```

در اینجا میتونیم مستقیم response رو برگردونیم و در [این شرط](https://github.com/IPeCompany/SmsPanelV2.Laravel/pull/19/files#diff-1e60c52af0a6ace274c6a7412c4c416b4add8cbff9d252aa096466bc6573c1ddR33-R36) بررسی کنیم اگر `$message` به عنوان response برگشت داده شده بود همونجا return کنیم.


هدف من از این تغییر انعطاف پذیری در response هست 

همچنین در یک پول رکوئست دیگر به داکیومنت مستندات رو اضافه خواهم کرد